### PR TITLE
[GOMO-131] window manager 버그 수정

### DIFF
--- a/src/components/window/window-manager.tsx
+++ b/src/components/window/window-manager.tsx
@@ -6,6 +6,8 @@ import { useWindowStore } from '@/stores'
 import { WindowView } from './window-view'
 import { AnimatePresence } from 'motion/react'
 
+const WINDOW_MANAGER_Z_INDEX = 500
+
 export function WindowManager() {
   const { views } = useWindowStore()
 
@@ -28,6 +30,7 @@ export function WindowManager() {
           justifyContent: 'center',
           alignItems: 'center',
           pointerEvents: 'none',
+          zIndex: WINDOW_MANAGER_Z_INDEX,
         }}
       >
         <Box id="window-manager" width={1} height={1}>


### PR DESCRIPTION
로그인 화면에서 로그인 이후 앱 화면으로 첫 진입시 서비스 내 윈도우 화면이 나타나지 않는 문제가 있었습니다. 원인 분석 결과 윈도우 화면은 정상적으로 생성되고 있었지만, 이미 로그인 되었을때와 달리 로그인 화면을 거치고 진입하는 과정에서 윈도우 창의 배경의 뒤로 밀려나는 문제를 발견했습니다.

이 문제를 해결하기 위해 `windowManager`의 `zIndex`를 500으로 설정했습니다. 이는 MUI의 다른 `zIndex`와 겹치지 않도록 설정한 값입니다.

[참고]
- https://mui.com/material-ui/customization/default-theme/?expand-path=$.zIndex