### PR TITLE
[GOMO-114] window manager 로그인 화면에 남아있는 버그 해결

### DIFF
--- a/src/layouts/main-layout.tsx
+++ b/src/layouts/main-layout.tsx
@@ -1,7 +1,6 @@
 import { fetches } from '@/api'
 import { AccessToken } from '@/auth/types'
 import { Toaster } from '@/components/toast'
-import { WindowManager } from '@/components/window'
 import { useEffectOnce } from '@/hooks'
 import { useAuthStore, useTokenStore } from '@/stores'
 import { theme } from '@/themes'
@@ -50,7 +49,6 @@ export function MainLayout() {
       <ThemeProvider theme={selectedTheme}>
         <CssBaseline />
         <Toaster />
-        <WindowManager />
         <Outlet />
       </ThemeProvider>
     </QueryClientProvider>

--- a/src/msw/handlers/auth.ts
+++ b/src/msw/handlers/auth.ts
@@ -16,4 +16,9 @@ export const auth = [
     //   { status: 404 }
     // )
   }),
+
+  http.post(endpoints.auth.reissue, async () => {
+    return HttpResponse.json(null, { status: 200 })
+    // return HttpResponse.json(null, { status: 401 })
+  }),
 ]

--- a/src/msw/handlers/member.ts
+++ b/src/msw/handlers/member.ts
@@ -12,8 +12,9 @@ import { delay, http, HttpResponse } from 'msw'
 export const member = [
   http.get<never, never>(endpoints.member.profile, async () => {
     await delay(1000)
-    // return HttpResponse.json(mock.member.profile, { status: 200 })
-    return new HttpResponse(null, { status: 400 })
+    return HttpResponse.json(mock.member.profile, { status: 200 })
+    // return new HttpResponse(null, { status: 400 })
+    // return new HttpResponse(null, { status: 401 })
   }),
 
   http.put<never, UpdateMemberRequest>(endpoints.member.update, async () => {

--- a/src/pages/main/main-page.tsx
+++ b/src/pages/main/main-page.tsx
@@ -2,6 +2,7 @@ import { FullContainer } from '@/components/container'
 import { SxProps, Theme } from '@mui/material'
 import { ControlPanel } from './components/control-panel'
 import { OnlyAuth } from '@/auth/guard'
+import { WindowManager } from '@/components/window'
 
 const backgroundSx: SxProps<Theme> = {
   backgroundImage: 'url("/img/room.png")',
@@ -16,6 +17,7 @@ export function MainPage() {
       <FullContainer sx={{ ...backgroundSx, position: 'relative' }}>
         <ControlPanel />
       </FullContainer>
+      <WindowManager />
     </OnlyAuth>
   )
 }


### PR DESCRIPTION
로그인 이후 애플리케이션 서비스 내부에서 사용하는 윈도우 창이 로그인 화면으로 이동 후에도 남아있는 문제를 해결했습니다.

모든 윈도우 창을 관리하는 `windowManager`의 위치가 기존에는 프로젝트 전체 범위인 `mainLayout`에 위치해 있었습니다. 이를 로그인 이후 접근할 수 있는 애플리케이션 범위인 `mainPage`로 위치를 이동시켰습니다.

이제는 다음과 같이 동작합니다.

- 윈도우 창이 떠있는 와중 갑작스럽게 로그인, 회원가입 등 애플리케이션 외부 범위로 벗어나는 순간 모든 윈도우 창 제거
- 이후 다시 로그인하여 기존 애플리케이션 화면으로 되돌아올 시, 이전의 윈도우 창 다시 복구

#### [수정 전]
![window-view-bug](https://github.com/user-attachments/assets/e017023b-0f7c-4188-8854-9e070b44c648)

#### [수정 후]
![window-view-bug-fix](https://github.com/user-attachments/assets/ec50894b-710e-489a-9ddc-56a64db2ba31)