### PR TITLE
[GOMO-132] refresh token이 저장되지 않는 문제 해결 시도

### DIFF
--- a/src/api/axios/axios.ts
+++ b/src/api/axios/axios.ts
@@ -12,6 +12,7 @@ export const AXIOS = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true,
 })
 
 setupAccessTokenInterceptor()


### PR DESCRIPTION
쿠키로 내려오는 리프레시 토큰이 저장되지 않는 문제가 확인되어, Axios의 `withCredentials` 세팅을 `true`로 변경하였습니다.