### PR TITLE
[GOMO-165] 퀘스트 설정 페이지

### DIFF
--- a/src/components/input/number-input.tsx
+++ b/src/components/input/number-input.tsx
@@ -1,4 +1,4 @@
-import { alpha, IconButton, Stack, Typography } from '@mui/material'
+import { IconButton, Stack, Typography } from '@mui/material'
 import { Iconify } from '@/components/iconify'
 import { useMemo, useState } from 'react'
 
@@ -30,7 +30,7 @@ export function NumberInput({
   const [innerValue, setInnerValue] = useState(defaultValue)
 
   const value = useMemo(() => {
-    if (props.value) {
+    if (props.value !== undefined) {
       return props.value
     }
     return innerValue
@@ -53,10 +53,20 @@ export function NumberInput({
   }
 
   return (
-    <Stack direction="row" alignItems="center" border={1} borderRadius={1} borderColor="divider">
+    <Stack
+      direction="row"
+      alignItems="center"
+      border={1}
+      borderRadius={1}
+      borderColor={(theme) => theme.palette.border.main}
+    >
       {indicator && (
         <IconButton
-          sx={{ borderRadius: 0, borderRight: 1, borderColor: 'divider' }}
+          sx={{
+            borderRadius: 0,
+            borderRight: 1,
+            borderColor: (theme) => theme.palette.border.main,
+          }}
           onClick={subHandler}
           disabled={disabled}
         >
@@ -70,7 +80,7 @@ export function NumberInput({
         alignItems="center"
         direction={unitPosition === 'left' ? 'row-reverse' : 'row'}
         spacing={0.2}
-        bgcolor={(theme) => alpha(theme.palette.background.paper, 0.4)}
+        bgcolor={(theme) => theme.palette.background.light}
       >
         <Typography variant="subtitle2" color={disabled ? 'text.disabled' : 'text.secondary'}>
           {value}
@@ -83,7 +93,11 @@ export function NumberInput({
       </Stack>
       {indicator && (
         <IconButton
-          sx={{ borderRadius: 0, borderLeft: 1, borderColor: 'divider' }}
+          sx={{
+            borderRadius: 0,
+            borderLeft: 1,
+            borderColor: (theme) => theme.palette.border.main,
+          }}
           onClick={addHandler}
           disabled={disabled}
         >

--- a/src/views/quest/modals/main/quest-modal-setting-list.tsx
+++ b/src/views/quest/modals/main/quest-modal-setting-list.tsx
@@ -1,0 +1,19 @@
+import { NumberInput } from '@/components/input'
+import { Stack, Typography } from '@mui/material'
+
+interface QuestModalSettingListProps {
+  title: string
+  value: number
+  onChange?: (value: number) => void
+}
+
+export function QuestModalSettingList({ title, value, onChange }: QuestModalSettingListProps) {
+  return (
+    <Stack direction="row" justifyContent="space-between" alignItems="center">
+      <Typography fontSize={14} fontWeight={500}>
+        {title}
+      </Typography>
+      <NumberInput indicator min={0} unit="개" value={value} onChange={onChange} />
+    </Stack>
+  )
+}

--- a/src/views/quest/modals/main/quest-modal-setting-section.tsx
+++ b/src/views/quest/modals/main/quest-modal-setting-section.tsx
@@ -1,0 +1,54 @@
+import { useQuestSetting } from '@/api/hooks'
+import { QuestModalSettingList } from '@/views/quest/modals/main/quest-modal-setting-list'
+import { Button, Stack } from '@mui/material'
+import { useEffect, useMemo, useState } from 'react'
+
+export function QuestModalSettingSection() {
+  const { questProperty, updateQuestProperty } = useQuestSetting()
+
+  const [dailyThreshold, setDailyThreshold] = useState(questProperty.dailyThreshold)
+  const [weeklyThreshold, setWeeklyThreshold] = useState(questProperty.weeklyThreshold)
+  const [monthlyThreshold, setMonthlyThreshold] = useState(questProperty.monthlyThreshold)
+
+  const updateHandler = () => {
+    updateQuestProperty({ dailyThreshold, weeklyThreshold, monthlyThreshold })
+  }
+
+  const isUpdated = useMemo(() => {
+    return (
+      dailyThreshold !== questProperty.dailyThreshold ||
+      weeklyThreshold !== questProperty.weeklyThreshold ||
+      monthlyThreshold !== questProperty.monthlyThreshold
+    )
+  }, [dailyThreshold, weeklyThreshold, monthlyThreshold, questProperty])
+
+  useEffect(() => {
+    console.log(questProperty)
+    setDailyThreshold(questProperty.dailyThreshold)
+    setWeeklyThreshold(questProperty.weeklyThreshold)
+    setMonthlyThreshold(questProperty.monthlyThreshold)
+  }, [questProperty])
+
+  return (
+    <Stack p={2} spacing={2}>
+      <QuestModalSettingList
+        title="일일 생성 퀘스트"
+        value={dailyThreshold}
+        onChange={setDailyThreshold}
+      />
+      <QuestModalSettingList
+        title="주간 생성 퀘스트"
+        value={weeklyThreshold}
+        onChange={setWeeklyThreshold}
+      />
+      <QuestModalSettingList
+        title="월간 생성 퀘스트"
+        value={monthlyThreshold}
+        onChange={setMonthlyThreshold}
+      />
+      <Button variant="contained" onClick={updateHandler} disabled={!isUpdated}>
+        설정 저장하기
+      </Button>
+    </Stack>
+  )
+}

--- a/src/views/quest/modals/main/quest-modal.tsx
+++ b/src/views/quest/modals/main/quest-modal.tsx
@@ -2,6 +2,7 @@ import { useAssignQuest } from '@/api/hooks'
 import { MainView } from '@/components/modal'
 import { MainViewSidebarMenuGroup } from '@/components/modal/main-view/main-view-sidebar'
 import { QuestModalQuestSection } from '@/views/quest/modals/main/quest-modal-quest-section'
+import { QuestModalSettingSection } from '@/views/quest/modals/main/quest-modal-setting-section'
 import { useState } from 'react'
 
 export const QUEST_MODAL_ID = 'QUEST_MODAL'
@@ -67,6 +68,7 @@ export function QuestModal({ initMenuId = 'DAILY_QUEST' }: QuestModalProps) {
       {selectedMenuId === 'MONTHLY_QUEST' && (
         <QuestModalQuestSection questType="MONTHLY" quests={monthly} />
       )}
+      {selectedMenuId === 'QUEST_SETTING' && <QuestModalSettingSection />}
     </MainView>
   )
 }


### PR DESCRIPTION
퀘스트 설정 페이지 개발하였습니다.

일일, 주간, 월간 최대 생성 가능한 퀘스트 개수를 설정할 수 있으며, 이전과 설정값이 달라질 경우에만 수정 버튼이 활성화됩니다.

- [x] 퀘스트 설정 페이지
- [x] `questProperty` API 훅과 연결
- [x] `number-input` 컴포넌트가 숫자 0일때 발생하던 버그 수정

![quest-setting](https://github.com/user-attachments/assets/39c89008-51ed-447a-a598-79e7b1748fad)
