### PR TITLE
[GOMO-163] 관심사 생성 시 상위 관심사가 자동 연결되지 않던 문제 해결

### DIFF
--- a/src/api/fetches/interest.ts
+++ b/src/api/fetches/interest.ts
@@ -24,9 +24,9 @@ import {
 export const interest = {
   create: async (params: CreateInterestFetchRequest): Promise<CreateInterestResponse> => {
     const formData = new FormData()
-    formData.append('name', params.body.request.name)
-    formData.append('colorCode', params.body.request.colorCode)
-    formData.append('logo', params.body.request.logo)
+    formData.append('name', params.body.name)
+    formData.append('colorCode', params.body.colorCode)
+    formData.append('logo', params.body.logo)
 
     return axiosFetch.postForm(endpoints.interest.create, formData, {
       onCode: {

--- a/src/api/hooks/api-mutate.ts
+++ b/src/api/hooks/api-mutate.ts
@@ -2,8 +2,8 @@ import { ErrorCode } from '@/api/error'
 import { apiErrorHandler } from '@/api/hooks/error-handler'
 import { UseMutateFunction } from '@tanstack/react-query'
 
-interface ApiMutateOptions {
-  onSuccess?: () => void
+interface ApiMutateOptions<T> {
+  onSuccess?: (data: T) => void
   onError?: (error: Error) => void
   onElse?: (error: Error) => void
   onCode?: Partial<Record<ErrorCode, (error: Error) => void>>
@@ -12,10 +12,10 @@ interface ApiMutateOptions {
 export function apiMutate<Response, Request>(
   mutate: UseMutateFunction<Response, Error, Request>,
   request: Request,
-  options?: ApiMutateOptions
+  options?: ApiMutateOptions<Response>
 ) {
   mutate(request, {
-    onSuccess: options?.onSuccess,
+    onSuccess: (data) => options?.onSuccess?.(data),
     onError: (err) => {
       options?.onError?.(err)
       apiErrorHandler(err, {

--- a/src/api/hooks/interest/use-create-interest.ts
+++ b/src/api/hooks/interest/use-create-interest.ts
@@ -2,17 +2,27 @@ import { fetches, endpoints } from '@/api'
 import { errorCode } from '@/api/error'
 import { apiMutate } from '@/api/hooks/api-mutate'
 import { QueryCallback } from '@/api/hooks/error-handler'
-import { CreateInterestRequest } from '@/api/types'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from '@/components/toast'
+import { useCreateInterestEdge } from '@/api/hooks/interest/use-create-interest-edge'
+import { CreateInterestResponse } from '@/api/types'
 
 interface CreateInterestCallback extends QueryCallback {
   onInvalidParameter?: () => void
   onImageTooLarge?: () => void
 }
 
+interface CreateInterestParams {
+  name: string
+  colorCode: string
+  logo: File
+  upperInterestId?: string
+}
+
 export function useCreateInterest() {
   const queryClient = useQueryClient()
+
+  const { createEdge } = useCreateInterestEdge()
 
   const { mutate } = useMutation({
     mutationKey: ['POST', endpoints.interest.create],
@@ -23,18 +33,38 @@ export function useCreateInterest() {
     },
   })
 
-  const createInterest = (body: CreateInterestRequest, callback?: CreateInterestCallback) => {
+  const onSuccessHandler = (
+    data: CreateInterestResponse,
+    params: CreateInterestParams,
+    callback?: CreateInterestCallback
+  ) => {
+    toast.success('관심사가 추가되었습니다.')
+    if (!params.upperInterestId) {
+      callback?.onSuccess?.()
+      return
+    }
+    createEdge(
+      {
+        parentInterestId: params.upperInterestId,
+        childInterestId: data.id,
+      },
+      { onSuccess: () => callback?.onSuccess?.() }
+    )
+  }
+
+  const createInterest = (params: CreateInterestParams, callback?: CreateInterestCallback) => {
+    const body = {
+      name: params.name,
+      colorCode: params.colorCode,
+      logo: params.logo,
+    }
+
     apiMutate(
       mutate,
       { body },
       {
-        onSuccess: () => {
-          toast.success('관심사가 추가되었습니다.')
-          callback?.onSuccess?.()
-        },
-        onError: () => {
-          callback?.onError?.()
-        },
+        onSuccess: (data) => onSuccessHandler(data, params, callback),
+        onError: () => callback?.onError?.(),
         onCode: {
           [errorCode.interest.create.INVALID_PARAMETER]: () => {
             toast.warning('관심사 이름에 사용할 수 없는 단어가 사용되었습니다.')

--- a/src/api/types/requests/interest.ts
+++ b/src/api/types/requests/interest.ts
@@ -3,11 +3,9 @@
 // ===================================
 
 interface CreateInterestRequest {
-  request: {
-    name: string
-    colorCode: string
-    logo: File
-  }
+  name: string
+  colorCode: string
+  logo: File
 }
 
 interface UpdateInterestRequest {

--- a/src/hooks/use-enter.ts
+++ b/src/hooks/use-enter.ts
@@ -2,14 +2,16 @@ import { useEffect } from 'react'
 
 export function useEnter(onEnter: () => void) {
   useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
+    const keyboardHandler = (event: KeyboardEvent) => {
+      console.log(event)
       if (event.key === 'Enter') {
         onEnter?.()
+        event.stopPropagation()
       }
     }
-    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keyup', keyboardHandler)
     return () => {
-      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keyup', keyboardHandler)
     }
   }, [onEnter])
 }

--- a/src/pages/interest/components/create-interest.tsx
+++ b/src/pages/interest/components/create-interest.tsx
@@ -19,11 +19,9 @@ export function CreateInterest() {
       return
     }
     createInterest({
-      request: {
-        name: interestName,
-        colorCode: '#000000',
-        logo: interestLogo,
-      },
+      name: interestName,
+      colorCode: '#000000',
+      logo: interestLogo,
     })
   }
 

--- a/src/views/interest/modals/create-interest/create-interest-modal-s1.tsx
+++ b/src/views/interest/modals/create-interest/create-interest-modal-s1.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/button'
+import { useEnter } from '@/hooks'
 import { CreateInterestModalStep } from '@/views/interest/modals/create-interest/create-interest-modal'
 import { Stack, TextField, Typography } from '@mui/material'
 
@@ -13,6 +14,12 @@ export function CreateInterestModalS1({
   name,
   setName,
 }: CreateInterestModalS1Props) {
+  useEnter(() => {
+    if (name.trim().length > 0) {
+      onNext?.()
+    }
+  })
+
   return (
     <Stack height={1} justifyContent="space-between" spacing={2}>
       <Stack spacing={3}>

--- a/src/views/interest/modals/create-interest/create-interest-modal-s2.tsx
+++ b/src/views/interest/modals/create-interest/create-interest-modal-s2.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/button'
 import { Interest } from '@/entities/interest'
+import { useEnter } from '@/hooks'
 import { SelectInterest } from '@/views/interest/components'
 import { CreateInterestModalStep } from '@/views/interest/modals/create-interest/create-interest-modal'
 import { Stack, Typography } from '@mui/material'
@@ -15,8 +16,12 @@ export function CreateInterestModalS2({
   interest,
   setInterest,
 }: CreateInterestModalS2Props) {
+  useEnter(() => {
+    onNext?.()
+  })
+
   return (
-    <Stack height={1} justifyContent="space-between" spacing={2}>
+    <Stack height={1} justifyContent="space-between" spacing={2} overflow="hidden">
       <Stack spacing={3} flex={1} overflow="hidden">
         <Stack spacing={1}>
           <Typography fontSize={18} fontWeight={600} noWrap flexShrink={0}>

--- a/src/views/interest/modals/create-interest/create-interest-modal-s3.tsx
+++ b/src/views/interest/modals/create-interest/create-interest-modal-s3.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/button'
+import { useEnter } from '@/hooks'
 import { SelectInterestColor, SelectInterestImage } from '@/views/interest/components'
 import { CreateInterestModalStep } from '@/views/interest/modals/create-interest/create-interest-modal'
 import { Stack, Typography } from '@mui/material'
@@ -18,6 +19,10 @@ export function CreateInterestModalS3({
   file,
   setFile,
 }: CreateInterestModalS3Props) {
+  useEnter(() => {
+    onNext?.()
+  })
+
   return (
     <Stack height={1} justifyContent="space-between" spacing={2}>
       <Stack spacing={2} flex={1} overflow="hidden">

--- a/src/views/interest/modals/create-interest/create-interest-modal.tsx
+++ b/src/views/interest/modals/create-interest/create-interest-modal.tsx
@@ -44,11 +44,10 @@ export function CreateInterestModal({ id: propsId }: CreateInterestModalProps) {
     }
     createInterest(
       {
-        request: {
-          name: name,
-          colorCode: color ?? '#000000',
-          logo: file,
-        },
+        name: name,
+        colorCode: color ?? '#000000',
+        logo: file,
+        upperInterestId: interest?.id,
       },
       {
         onSuccess: closeModal,


### PR DESCRIPTION
기존 api 특성 상 관심사 생성 시 바로 상위 관심사를 연결할 수 없었습니다. 이에 프론트엔드 단의 api 훅에서 자동으로 관심사 생성 시 생성 api를 호출한 이후, 이어서 상위 관심사를 연결 api를 호출할 수 있도록 로직을 수정했습니다.

하나의 동작을 2개의 나눠진 api로 수행하는 건에 대해서는 실제 배포 환경에서 얼마나 잘 작동하는지 확인해보고, 실패율이 많아지는 경우 하나의 api로 만드는 방식으로 수정하는 것이 좋아보입니다.