### PR TITLE
[GOMO-164] 관심사 그래프 svg 크기 변경이 되지 않는 문제 해결

### DIFF
--- a/src/components/force-directed-graph/d3/use-force-directed-graph.ts
+++ b/src/components/force-directed-graph/d3/use-force-directed-graph.ts
@@ -1,4 +1,3 @@
-import { useWindowViewContext } from '@/components/window'
 import { MouseEvent, useCallback, useEffect, useRef, useState } from 'react'
 import * as d3 from 'd3'
 import {
@@ -10,13 +9,14 @@ import {
   useForceDirectedGraphSelect,
 } from '@/components/force-directed-graph/d3'
 import { Graph, Vertex } from '@/components/force-directed-graph/types'
-import { cloneDeep } from 'lodash'
+import { cloneDeep, debounce } from 'lodash'
+import { useToggleSignal } from '@/hooks/use-toggle-signal'
 
 export function useForceDirectedGraph<V extends Vertex>(
   data: Graph<V>,
   onSelect?: (interest: V | null) => void
 ) {
-  const { viewSize } = useWindowViewContext()
+  const { value: resize, toggle: onResize } = useToggleSignal()
 
   const svgRef = useRef<SVGSVGElement>(null)
   const { setSelectedVertexId } = useForceDirectedGraphSelect(svgRef)
@@ -78,7 +78,16 @@ export function useForceDirectedGraph<V extends Vertex>(
       vertex.attr('transform', (d) => `translate(${d.x},${d.y})`)
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [graphData, viewSize])
+  }, [graphData, resize])
+
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver(debounce(onResize, 500))
+    resizeObserver.observe(svgRef.current!)
+    return () => {
+      resizeObserver.disconnect()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return { svgRef, onSvgClickHandler }
 }

--- a/src/views/interest/components/interest-graph-indicator/interest-graph-indicator.tsx
+++ b/src/views/interest/components/interest-graph-indicator/interest-graph-indicator.tsx
@@ -66,7 +66,7 @@ export function InterestGraphIndicator({ interest }: InterestGraphIndicatorProps
 
       <Box width={1} borderBottom={1} borderColor={(theme) => theme.palette.border.main} />
 
-      <Stack direction="row" spacing={0.5} flexWrap="wrap">
+      <Stack direction="row" gap={0.5} flexWrap="wrap">
         {upperInterests.map((interest) => (
           <InterestGraphIndicatorTag key={interest.id} tag={interest.name} isUpper />
         ))}


### PR DESCRIPTION
관심사 페이지를 열어 확인하는 관심사 그래프의 크기가 관심사 페이지를 여는 시점의 브라우저 크기에 맞춰 고정되는 문제가 존재했습니다.

이를 해결하기 위해 기존에 사용하던 useWindowViewContext 방식 대신 ResizeObserver 방식으로 변경하였습니다. 이를 통해 다음과 같이 개선되었습니다.

1. windowViewContext를 상위 컴포넌트에서 직접 관리하지 않아도 됩니다. (관심사 분리)
2. 웹 브라우저에서 기본으로 제공하는 ResizeObserver API를 활용하여 범용성과 코드 이해도를 높였습니다.

추가로 창의 크기 리사이즈는 연속적으로 발생하기 쉬운 이벤트이기에 따로 디바운스 처리를 하였습니다. 따라서 창의 크기 변경이 계속해서 일어나는 동안은 따로 동작하지 않고, 마지막 이벤트가 종료되고 500ms 동안 추가적인 반응이 없다면 실행됩니다.

이를 통해 창의 크기가 변경되는 순간순간마다 계속해서 그래프가 떨리며 모양이 변경되는 모습을 방지하고, 성능을 최적화시켰습니다.

![debounce-resize](https://github.com/user-attachments/assets/87d7c7aa-ec22-4419-9b07-dd8e0ac98c2e)

추가 수정) 관심사 인디케이터의 태그가 2줄 이상 존재할 경우 제대로 된 간격이 생성되지 않는 문제를 발견하여 함께 조치하였습니다.
