### PR TITLE
[GOMO-172] 기록 페이지

### DIFF
--- a/src/api/hooks/history/index.ts
+++ b/src/api/hooks/history/index.ts
@@ -1,9 +1,12 @@
 import { useGetHistory } from './use-get-history'
+import { useGetDailyTotalHistory } from './use-get-daily-total-history'
 
 export * from './use-get-history'
+export * from './use-get-daily-total-history'
 
 export function useHistory(year: number, month: number) {
   const { history, isLoading } = useGetHistory(year, month)
+  const { dailyTotalHistory } = useGetDailyTotalHistory(year, month)
 
-  return { history, isLoading }
+  return { history, dailyTotalHistory, isLoading }
 }

--- a/src/api/hooks/history/use-get-daily-total-history.ts
+++ b/src/api/hooks/history/use-get-daily-total-history.ts
@@ -1,0 +1,19 @@
+import { useGetHistory } from '@/api/hooks/history'
+import { DailyTotalAssignQuestHistory } from '@/entities'
+
+import { useMemo } from 'react'
+
+export function useGetDailyTotalHistory(year: number, month: number) {
+  const { history } = useGetHistory(year, month)
+
+  const dailyTotalHistory = useMemo<DailyTotalAssignQuestHistory[]>(() => {
+    return history.map((e) => ({
+      date: e.date,
+      dailyCount: e.history.filter((e) => e.questType === 'DAILY').length,
+      weeklyCount: e.history.filter((e) => e.questType === 'WEEKLY').length,
+      monthlyCount: e.history.filter((e) => e.questType === 'MONTHLY').length,
+    }))
+  }, [history])
+
+  return { dailyTotalHistory }
+}

--- a/src/components/heatmap/calendar/calendar-cell.tsx
+++ b/src/components/heatmap/calendar/calendar-cell.tsx
@@ -12,9 +12,10 @@ dayjs.extend(weekOfYear)
 interface CalendarCellProps {
   data: CellData
   onClick?: (date: Date) => void
+  unselected?: boolean
 }
 
-export function CalendarCell({ data: cell, onClick }: CalendarCellProps) {
+export function CalendarCell({ data: cell, unselected, onClick }: CalendarCellProps) {
   const { color, emptyColor, thresholds, width, height, type, customFn } =
     useHeatmapCalendarContext()
 
@@ -48,7 +49,7 @@ export function CalendarCell({ data: cell, onClick }: CalendarCellProps) {
         borderRadius={1}
         bgcolor={options.bgcolor}
         onClick={() => onClick?.(cell.date!)}
-        sx={{ cursor: 'pointer', ':hover': { border: 1 } }}
+        sx={{ cursor: 'pointer', opacity: unselected ? 0.3 : 1 }}
       />
     </Tooltip>
   )

--- a/src/components/heatmap/calendar/calendar-heatmap.tsx
+++ b/src/components/heatmap/calendar/calendar-heatmap.tsx
@@ -18,9 +18,11 @@ interface CalendarHeatmapProps {
   color?: string
   thresholds?: number[]
   customFn?: (count: number) => string
+  onSelect?: (date: Date) => void
   onClick?: (date: Date) => void
   sx?: SxProps<Theme>
   type?: CalendarHeatmapType
+  selectedDate?: Date | null
 }
 
 const DEFAULT_CELL_SIZE = 15
@@ -33,7 +35,9 @@ export function CalendarHeatmap({
   color: customColor,
   thresholds = DEFAULT_THREASHOLDS,
   cellSize = DEFAULT_CELL_SIZE,
+  selectedDate,
   customFn,
+  onSelect,
   onClick,
   sx,
 }: CalendarHeatmapProps) {
@@ -55,6 +59,16 @@ export function CalendarHeatmap({
     }
     return dailyCells
   }, [dailyCells, monthlyCells, weeklyCells, type])
+
+  const clickHandler = (date: Date | null, count: number) => {
+    if (date === null) {
+      return
+    }
+    if (count > 0) {
+      onSelect?.(date!)
+    }
+    onClick?.(date)
+  }
 
   const context = useMemo(() => {
     const context: IHeatmapCalendarContext = {
@@ -101,11 +115,16 @@ export function CalendarHeatmap({
         {/* Cell area */}
         <HeatmapCalendarProvider context={context}>
           <ScrollContainer>
-            <Stack spacing="2px" direction="row">
+            <Stack spacing="2px" direction="row" pb={2}>
               {cells.map((column, i) => (
                 <Stack key={i} spacing="2px">
                   {column.map((cell, j) => (
-                    <CalendarCell key={j} data={cell} onClick={onClick} />
+                    <CalendarCell
+                      key={j}
+                      data={cell}
+                      onClick={() => clickHandler(cell.date, cell.count)}
+                      unselected={!!selectedDate && selectedDate.getTime() !== cell.date?.getTime()}
+                    />
                   ))}
                 </Stack>
               ))}

--- a/src/components/selector/index.ts
+++ b/src/components/selector/index.ts
@@ -1,3 +1,4 @@
 export * from './vertical-selector'
 export * from './month-selector'
 export * from './year-selector'
+export * from './streak-selector'

--- a/src/components/selector/index.ts
+++ b/src/components/selector/index.ts
@@ -1,1 +1,3 @@
 export * from './vertical-selector'
+export * from './month-selector'
+export * from './year-selector'

--- a/src/components/selector/month-selector.tsx
+++ b/src/components/selector/month-selector.tsx
@@ -1,0 +1,24 @@
+import { FormControl, FormControlProps, MenuItem, Select } from '@mui/material'
+import range from 'lodash/range'
+
+interface MonthSelectorProps extends Omit<FormControlProps, 'onChange'> {
+  value: number
+  onChange: (value: number) => void
+}
+
+export function MonthSelector({ value, onChange, ...formProps }: MonthSelectorProps) {
+  const months = range(1, 13)
+
+  return (
+    <FormControl {...formProps}>
+      {/* <InputLabel>월</InputLabel> */}
+      <Select value={value} onChange={(e) => onChange(Number(e.target.value))}>
+        {months.map((month) => (
+          <MenuItem key={month} value={month}>
+            {month}월
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  )
+}

--- a/src/components/selector/streak-selector.tsx
+++ b/src/components/selector/streak-selector.tsx
@@ -1,0 +1,25 @@
+import { FormControl, FormControlProps, MenuItem, Select } from '@mui/material'
+import range from 'lodash/range'
+
+interface StreakSelectorProps extends Omit<FormControlProps, 'onChange'> {
+  value: number
+  onChange?: (value: number) => void
+}
+
+export function StreakSelector({ value, onChange, ...formProps }: StreakSelectorProps) {
+  const currentYear = new Date().getFullYear()
+  const years = range(currentYear, 2022, -1)
+
+  return (
+    <FormControl {...formProps}>
+      <Select value={value} onChange={(e) => onChange?.(Number(e.target.value))}>
+        <MenuItem value={-1}>최근</MenuItem>
+        {years.map((year) => (
+          <MenuItem key={year} value={year}>
+            {year}년
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  )
+}

--- a/src/components/selector/year-selector.tsx
+++ b/src/components/selector/year-selector.tsx
@@ -1,0 +1,25 @@
+import { FormControl, FormControlProps, MenuItem, Select } from '@mui/material'
+import range from 'lodash/range'
+
+interface YearSelectorProps extends Omit<FormControlProps, 'onChange'> {
+  value: number
+  onChange: (value: number) => void
+}
+
+export function YearSelector({ value, onChange, ...formProps }: YearSelectorProps) {
+  const currentYear = new Date().getFullYear()
+  const years = range(currentYear, 2022, -1)
+
+  return (
+    <FormControl {...formProps}>
+      {/* <InputLabel>연도</InputLabel> */}
+      <Select value={value} onChange={(e) => onChange(Number(e.target.value))}>
+        {years.map((year) => (
+          <MenuItem key={year} value={year}>
+            {year}년
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  )
+}

--- a/src/entities/history/history.ts
+++ b/src/entities/history/history.ts
@@ -15,4 +15,11 @@ interface OrganizedAssignQuestHistory {
   history: AssignQuestHistory[]
 }
 
-export type { AssignQuestHistory, OrganizedAssignQuestHistory }
+interface DailyTotalAssignQuestHistory {
+  date: Date
+  dailyCount: number
+  weeklyCount: number
+  monthlyCount: number
+}
+
+export type { AssignQuestHistory, OrganizedAssignQuestHistory, DailyTotalAssignQuestHistory }

--- a/src/entities/history/index.ts
+++ b/src/entities/history/index.ts
@@ -1,0 +1,1 @@
+export type * from './history'

--- a/src/pages/main/main-page.tsx
+++ b/src/pages/main/main-page.tsx
@@ -7,6 +7,7 @@ import MonthlyQuestWidget from '@/views/quest/widgets/monthly-quest'
 import InterestGraphWidget from '@/views/interest/widgets/interest-graph'
 import MyProfileWidget from '@/views/profile/widgets/my-profile'
 import QuestHistoryWidget from '@/views/history/widgets/quest-history'
+import QuestStreakWidget from '@/views/history/widgets/quest-streak'
 
 const backgroundSx: SxProps<Theme> = {
   backgroundImage: 'url("/img/bg.jpg")',
@@ -22,6 +23,7 @@ export function MainPage() {
       <Stack width={1} alignItems="center" px={4} py={15}>
         <Box display="flex" gap="40px" flexWrap="wrap">
           <MyProfileWidget.S1x1 />
+          <QuestStreakWidget.S1x3 />
           <QuestHistoryWidget.S1x1 />
           <InterestGraphWidget.S1x1 />
           <DailyQuestWidget.S1x1 />

--- a/src/pages/main/main-page.tsx
+++ b/src/pages/main/main-page.tsx
@@ -6,6 +6,7 @@ import WeeklyQuestWidget from '@/views/quest/widgets/weekly-quest'
 import MonthlyQuestWidget from '@/views/quest/widgets/monthly-quest'
 import InterestGraphWidget from '@/views/interest/widgets/interest-graph'
 import MyProfileWidget from '@/views/profile/widgets/my-profile'
+import QuestHistoryWidget from '@/views/history/widgets/quest-history'
 
 const backgroundSx: SxProps<Theme> = {
   backgroundImage: 'url("/img/bg.jpg")',
@@ -21,6 +22,7 @@ export function MainPage() {
       <Stack width={1} alignItems="center" px={4} py={15}>
         <Box display="flex" gap="40px" flexWrap="wrap">
           <MyProfileWidget.S1x1 />
+          <QuestHistoryWidget.S1x1 />
           <InterestGraphWidget.S1x1 />
           <DailyQuestWidget.S1x1 />
           <DailyQuestWidget.S1x2 />

--- a/src/themes/components/index.ts
+++ b/src/themes/components/index.ts
@@ -1,7 +1,9 @@
 import { button } from '@/themes/components/button'
+import { menu } from '@/themes/components/menu'
 import { tooltip } from '@/themes/components/tooltip'
 
 export const components = {
   ...button,
   ...tooltip,
+  ...menu,
 }

--- a/src/themes/components/menu.ts
+++ b/src/themes/components/menu.ts
@@ -1,0 +1,13 @@
+import { Components, Theme } from '@mui/material'
+
+const MuiMenu: Components<Theme>['MuiMenu'] = {
+  styleOverrides: {
+    paper: ({ theme }: { theme: Theme }) => ({
+      boxShadow: 'none',
+      border: `1px solid ${theme.palette.divider}`,
+      marginTop: '5px',
+    }),
+  },
+}
+
+export const menu = { MuiMenu }

--- a/src/views/history/components/daily-total-history-item.tsx
+++ b/src/views/history/components/daily-total-history-item.tsx
@@ -1,0 +1,43 @@
+import { Iconify } from '@/components/iconify'
+import { Box, Stack, Typography } from '@mui/material'
+import dayjs from 'dayjs'
+
+interface DailyTotalHistoryItemProps {
+  date: Date
+  dailyCount: number
+  weeklyCount: number
+  monthlyCount: number
+}
+
+export function DailyTotalHistoryItem({
+  date,
+  dailyCount,
+  weeklyCount,
+  monthlyCount,
+}: DailyTotalHistoryItemProps) {
+  return (
+    <Stack
+      p={1}
+      spacing={0.5}
+      borderRadius={1}
+      sx={{ '&:hover': { bgcolor: (theme) => theme.palette.background.main }, cursor: 'pointer' }}
+    >
+      <Stack direction="row" alignItems="center" spacing={2}>
+        <Iconify icon="material-symbols:commit" />
+        <Typography fontSize={15} fontWeight={500}>
+          {dayjs(date).format('YYYY년 MM월 DD일')}
+        </Typography>
+      </Stack>
+      <Stack direction="row" spacing={2}>
+        <Box width={20} />
+        <Stack direction="row" alignItems="center" divider={<Iconify icon="mdi:dot" width={15} />}>
+          {dailyCount > 0 && <Typography variant="caption">일일퀘스트 {dailyCount}개</Typography>}
+          {weeklyCount > 0 && <Typography variant="caption">주간퀘스트 {weeklyCount}개</Typography>}
+          {monthlyCount > 0 && (
+            <Typography variant="caption">월간퀘스트 {monthlyCount}개</Typography>
+          )}
+        </Stack>
+      </Stack>
+    </Stack>
+  )
+}

--- a/src/views/history/components/history-list-item.tsx
+++ b/src/views/history/components/history-list-item.tsx
@@ -1,0 +1,28 @@
+import { Iconify } from '@/components/iconify'
+import { QUEST_TYPE, QuestType } from '@/entities/quest'
+import { Stack, Typography } from '@mui/material'
+import dayjs from 'dayjs'
+
+interface HistoryListItemProps {
+  content: string
+  questType: QuestType
+  interestName: string
+  date: Date | null
+}
+
+export function HistoryListItem({ content, questType, interestName, date }: HistoryListItemProps) {
+  return (
+    <Stack
+      p={1}
+      borderRadius={1}
+      sx={{ '&:hover': { bgcolor: (theme) => theme.palette.background.main }, cursor: 'pointer' }}
+    >
+      <Typography noWrap>{content}</Typography>
+      <Stack direction="row" alignItems="center" divider={<Iconify icon="mdi:dot" width={15} />}>
+        <Typography variant="caption">{QUEST_TYPE[questType].label}</Typography>
+        <Typography variant="caption">{interestName}</Typography>
+        <Typography variant="caption">{dayjs(date).format('HH:mm')} 완료</Typography>
+      </Stack>
+    </Stack>
+  )
+}

--- a/src/views/history/components/index.ts
+++ b/src/views/history/components/index.ts
@@ -1,0 +1,1 @@
+export * from './daily-total-history-item'

--- a/src/views/history/components/index.ts
+++ b/src/views/history/components/index.ts
@@ -1,1 +1,2 @@
 export * from './daily-total-history-item'
+export * from './history-list-item'

--- a/src/views/history/modals/index.ts
+++ b/src/views/history/modals/index.ts
@@ -1,0 +1,1 @@
+export * from './main/history-modal'

--- a/src/views/history/modals/main/history-modal.tsx
+++ b/src/views/history/modals/main/history-modal.tsx
@@ -1,5 +1,6 @@
 import { MainView } from '@/components/modal'
 import { MainViewSidebarMenuGroup } from '@/components/modal/main-view/main-view-sidebar'
+import { ListHistorySection } from '@/views/history/modals/main/list-history-section'
 import { useState } from 'react'
 
 export const HISTORY_MODAL_ID = 'HISTORY_MODAL'
@@ -39,6 +40,8 @@ export function HistoryModal({ initMenuId = 'HISTORY_LIST' }: HistoryModalProps)
       sidebar={SIDEBAR_MENU}
       selectedMenuId={selectedMenuId}
       onSelected={setSelectedMenuId}
-    ></MainView>
+    >
+      {selectedMenuId === 'HISTORY_LIST' && <ListHistorySection />}
+    </MainView>
   )
 }

--- a/src/views/history/modals/main/history-modal.tsx
+++ b/src/views/history/modals/main/history-modal.tsx
@@ -1,5 +1,6 @@
 import { MainView } from '@/components/modal'
 import { MainViewSidebarMenuGroup } from '@/components/modal/main-view/main-view-sidebar'
+import { HistoryStreakSection } from '@/views/history/modals/main/history-streak-section'
 import { ListHistorySection } from '@/views/history/modals/main/list-history-section'
 import { useState } from 'react'
 
@@ -14,10 +15,10 @@ const SIDEBAR_MENU: MainViewSidebarMenuGroup<HISTORY_MODAL_SIDEBAR_MENU_ID>[] = 
         id: 'HISTORY_LIST',
         label: '리스트 기록',
       },
-      {
-        id: 'HISTORY_CALENDAR',
-        label: '캘린더 기록',
-      },
+      // {
+      //   id: 'HISTORY_CALENDAR',
+      //   label: '캘린더 기록',
+      // },
       {
         id: 'HISTORY_STREAK',
         label: '연속 퀘스트 기록',
@@ -42,6 +43,7 @@ export function HistoryModal({ initMenuId = 'HISTORY_LIST' }: HistoryModalProps)
       onSelected={setSelectedMenuId}
     >
       {selectedMenuId === 'HISTORY_LIST' && <ListHistorySection />}
+      {selectedMenuId === 'HISTORY_STREAK' && <HistoryStreakSection />}
     </MainView>
   )
 }

--- a/src/views/history/modals/main/history-modal.tsx
+++ b/src/views/history/modals/main/history-modal.tsx
@@ -1,0 +1,44 @@
+import { MainView } from '@/components/modal'
+import { MainViewSidebarMenuGroup } from '@/components/modal/main-view/main-view-sidebar'
+import { useState } from 'react'
+
+export const HISTORY_MODAL_ID = 'HISTORY_MODAL'
+
+export type HISTORY_MODAL_SIDEBAR_MENU_ID = 'HISTORY_LIST' | 'HISTORY_CALENDAR' | 'HISTORY_STREAK'
+
+const SIDEBAR_MENU: MainViewSidebarMenuGroup<HISTORY_MODAL_SIDEBAR_MENU_ID>[] = [
+  {
+    menu: [
+      {
+        id: 'HISTORY_LIST',
+        label: '리스트 기록',
+      },
+      {
+        id: 'HISTORY_CALENDAR',
+        label: '캘린더 기록',
+      },
+      {
+        id: 'HISTORY_STREAK',
+        label: '연속 퀘스트 기록',
+      },
+    ],
+  },
+]
+
+interface HistoryModalProps {
+  initMenuId?: HISTORY_MODAL_SIDEBAR_MENU_ID
+}
+
+export function HistoryModal({ initMenuId = 'HISTORY_LIST' }: HistoryModalProps) {
+  const [selectedMenuId, setSelectedMenuId] = useState<HISTORY_MODAL_SIDEBAR_MENU_ID>(initMenuId)
+
+  return (
+    <MainView
+      title="퀘스트 기록"
+      modalId={HISTORY_MODAL_ID}
+      sidebar={SIDEBAR_MENU}
+      selectedMenuId={selectedMenuId}
+      onSelected={setSelectedMenuId}
+    ></MainView>
+  )
+}

--- a/src/views/history/modals/main/history-streak-section.tsx
+++ b/src/views/history/modals/main/history-streak-section.tsx
@@ -1,0 +1,68 @@
+import { useStreak } from '@/api/hooks'
+import { CalendarHeatmap } from '@/components/heatmap'
+import { StreakSelector } from '@/components/selector'
+import { Box, Stack, Typography } from '@mui/material'
+import dayjs from 'dayjs'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+export function HistoryStreakSection() {
+  const [year, setYear] = useState<number>(-1)
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null)
+
+  const streakRef = useRef<HTMLDivElement>(null)
+
+  const endDate = useMemo(() => {
+    if (year === -1) {
+      return dayjs().startOf('day').toDate()
+    }
+    return dayjs().year(year).endOf('year').endOf('day').toDate()
+  }, [year])
+
+  const startDate = useMemo(() => {
+    return dayjs(endDate).subtract(1, 'year').startOf('day').toDate()
+  }, [endDate])
+
+  const { streak } = useStreak(startDate, endDate)
+
+  useEffect(() => {
+    const clickHandler = (e: MouseEvent) => {
+      if (selectedDate !== null && !streakRef.current?.contains(e.target as Node)) {
+        setSelectedDate(null)
+      }
+    }
+    window.addEventListener('click', clickHandler)
+    return () => window.removeEventListener('click', clickHandler)
+  }, [selectedDate])
+
+  return (
+    <Stack>
+      <Stack
+        direction="row"
+        spacing={1}
+        alignItems="center"
+        bgcolor={(theme) => theme.palette.background.default}
+        p={1}
+        borderBottom={1}
+        borderColor={(theme) => theme.palette.divider}
+      >
+        <StreakSelector value={year} onChange={setYear} size="small" sx={{ width: 100 }} />
+      </Stack>
+      <Box p={2} ref={streakRef}>
+        <CalendarHeatmap
+          data={streak.daily}
+          endDate={endDate}
+          type="DAILY"
+          selectedDate={selectedDate}
+          onSelect={setSelectedDate}
+        />
+      </Box>
+      {!!selectedDate && (
+        <Stack px={2}>
+          <Typography fontSize={20} fontWeight={700} color="primary">
+            {dayjs(selectedDate).format('YYYY년 MM월 DD일')}
+          </Typography>
+        </Stack>
+      )}
+    </Stack>
+  )
+}

--- a/src/views/history/modals/main/list-history-section.tsx
+++ b/src/views/history/modals/main/list-history-section.tsx
@@ -1,0 +1,54 @@
+import { useHistory } from '@/api/hooks'
+import { MonthSelector, YearSelector } from '@/components/selector'
+import { HistoryListItem } from '@/views/history/components'
+import { Divider, Stack, Typography } from '@mui/material'
+import dayjs from 'dayjs'
+import { useState } from 'react'
+
+export function ListHistorySection() {
+  const now = new Date()
+
+  const [year, setYear] = useState(now.getFullYear())
+  const [month, setMonth] = useState(now.getMonth() + 1)
+
+  const { history } = useHistory(year, month)
+
+  return (
+    <Stack>
+      <Stack
+        direction="row"
+        spacing={1}
+        alignItems="center"
+        position="sticky"
+        top={0}
+        bgcolor={(theme) => theme.palette.background.default}
+        p={1}
+        borderBottom={1}
+        borderColor={(theme) => theme.palette.divider}
+      >
+        <YearSelector value={year} onChange={setYear} size="small" />
+        <MonthSelector value={month} onChange={setMonth} size="small" />
+      </Stack>
+      <Stack spacing={2} p={2} divider={<Divider />}>
+        {history.map((e) => (
+          <Stack key={e.date.getTime()} spacing={1}>
+            <Typography fontSize={18} fontWeight={600} pl={1} color="primary">
+              {dayjs(e.date).format('MM월 DD일')}
+            </Typography>
+            <Stack>
+              {e.history.map((history) => (
+                <HistoryListItem
+                  key={history.id}
+                  content={history.content}
+                  questType={history.questType}
+                  interestName={history.subjectName}
+                  date={history.completedDateTime}
+                />
+              ))}
+            </Stack>
+          </Stack>
+        ))}
+      </Stack>
+    </Stack>
+  )
+}

--- a/src/views/history/widgets/quest-history/index.ts
+++ b/src/views/history/widgets/quest-history/index.ts
@@ -1,0 +1,6 @@
+import { QuestHistoryWidget1x1 } from '@/views/history/widgets/quest-history/quest-history-widget-1x1'
+
+const QuestHistoryWidget = {
+  S1x1: QuestHistoryWidget1x1,
+}
+export default QuestHistoryWidget

--- a/src/views/history/widgets/quest-history/quest-history-widget-1x1.tsx
+++ b/src/views/history/widgets/quest-history/quest-history-widget-1x1.tsx
@@ -1,0 +1,24 @@
+import { useHistory } from '@/api/hooks'
+import { Widget } from '@/components/widget'
+import { DailyTotalHistoryItem } from '@/views/history/components'
+import { Stack } from '@mui/material'
+import dayjs from 'dayjs'
+import _ from 'lodash'
+
+export function QuestHistoryWidget1x1() {
+  const now = new Date()
+  const [year, month] = [now.getFullYear(), now.getMonth() + 1]
+
+  const { dailyTotalHistory } = useHistory(year, month)
+
+  return (
+    <Widget width={1} title="퀘스트 기록" subtitle={dayjs(now).format('YYYY년 MM월 DD일')}>
+      <Stack p={1}>
+        {_(dailyTotalHistory)
+          .take(4)
+          .map((data, i) => <DailyTotalHistoryItem key={i} {...data} />)
+          .value()}
+      </Stack>
+    </Widget>
+  )
+}

--- a/src/views/history/widgets/quest-history/quest-history-widget-1x1.tsx
+++ b/src/views/history/widgets/quest-history/quest-history-widget-1x1.tsx
@@ -1,6 +1,8 @@
 import { useHistory } from '@/api/hooks'
 import { Widget } from '@/components/widget'
+import { useModalStore } from '@/stores/use-modal-store'
 import { DailyTotalHistoryItem } from '@/views/history/components'
+import { HISTORY_MODAL_ID, HistoryModal } from '@/views/history/modals'
 import { Stack } from '@mui/material'
 import dayjs from 'dayjs'
 import _ from 'lodash'
@@ -10,9 +12,19 @@ export function QuestHistoryWidget1x1() {
   const [year, month] = [now.getFullYear(), now.getMonth() + 1]
 
   const { dailyTotalHistory } = useHistory(year, month)
+  const { addModal } = useModalStore()
+
+  const openHistoryModal = () => {
+    addModal(HISTORY_MODAL_ID, <HistoryModal />)
+  }
 
   return (
-    <Widget width={1} title="퀘스트 기록" subtitle={dayjs(now).format('YYYY년 MM월 DD일')}>
+    <Widget
+      width={1}
+      title="퀘스트 기록"
+      subtitle={dayjs(now).format('YYYY년 MM월 DD일')}
+      onTitle={openHistoryModal}
+    >
       <Stack p={1}>
         {_(dailyTotalHistory)
           .take(4)

--- a/src/views/history/widgets/quest-streak/index.ts
+++ b/src/views/history/widgets/quest-streak/index.ts
@@ -1,0 +1,6 @@
+import { QuestStreakWidget1x3 } from '@/views/history/widgets/quest-streak/quest-streak-widget-1x3'
+
+const QuestStreakWidget = {
+  S1x3: QuestStreakWidget1x3,
+}
+export default QuestStreakWidget

--- a/src/views/history/widgets/quest-streak/quest-streak-widget-1x3.tsx
+++ b/src/views/history/widgets/quest-streak/quest-streak-widget-1x3.tsx
@@ -1,0 +1,33 @@
+import { useStreak } from '@/api/hooks'
+import { CalendarHeatmap } from '@/components/heatmap'
+import { Widget } from '@/components/widget'
+import { useModalStore } from '@/stores/use-modal-store'
+import { HISTORY_MODAL_ID, HistoryModal } from '@/views/history/modals'
+import { Stack } from '@mui/material'
+import dayjs from 'dayjs'
+
+export function QuestStreakWidget1x3() {
+  const endDate = dayjs().endOf('day').toDate()
+  const startDate = dayjs(endDate).subtract(1, 'year').startOf('day').toDate()
+
+  const { addModal } = useModalStore()
+
+  const openHistoryModal = () => {
+    addModal(HISTORY_MODAL_ID, <HistoryModal initMenuId="HISTORY_STREAK" />)
+  }
+
+  const { streak } = useStreak(startDate, endDate)
+
+  return (
+    <Widget
+      width={3}
+      title="퀘스트 연속 기록"
+      subtitle="XXX일 연속 퀘스트 진행중"
+      onTitle={openHistoryModal}
+    >
+      <Stack width={1} height={1} justifyContent="center" alignItems="center">
+        <CalendarHeatmap data={streak.daily} endDate={endDate} type="DAILY" cellSize={17} />
+      </Stack>
+    </Widget>
+  )
+}

--- a/src/views/quest/components/quest-list-item.tsx
+++ b/src/views/quest/components/quest-list-item.tsx
@@ -152,7 +152,7 @@ export function QuestListItem({
           <Box width={30} />
           <Stack direction="row" alignItems="center">
             <Typography variant="caption">{QUEST_TYPE[quest.questType].label}</Typography>
-            <Iconify icon="mdi:dot" sx={{ width: 15 }} width={15} />
+            <Iconify icon="mdi:dot" width={15} />
             <Typography variant="caption">{quest.subjectName}</Typography>
             <Typography
               variant="caption"


### PR DESCRIPTION
기록 페이지 및 관련 위젯 개발하였습니다.

- [x] 기록 페이지 - 리스트 보기
- [x] 기록 페이지 - 스트릭 보기
- [x] 일일 기록 리스트 위젯(1x1)
- [x] 기록 스트릭 위젯(1x3)

<img width="1170" alt="image" src="https://github.com/user-attachments/assets/87578eed-dba4-4858-8082-a508d4379c9a" />

<img width="1170" alt="image" src="https://github.com/user-attachments/assets/f2529fa3-ecaf-4d44-bab4-4960b8820d48" />

#### 추가사항

- 캘린더 보기 섹션은 구상 및 개발중에 있습니다.
- 스트릭 데이터를 받아올 때 스트릭 몇 일을 연속 유지 중인지, 또는 최장 스트릭 유지 기간이 몇 일이었는지 등의 정보가 필요합니다.
- 특정 날짜의 기록 데이터를 받아올 수 있는 api가 필요합니다.
