### PR TITLE
[GOMO-179] JWT 문제 해결

### DIFF
--- a/src/api/axios/interceptors/refresh-token.ts
+++ b/src/api/axios/interceptors/refresh-token.ts
@@ -5,7 +5,7 @@ import { useTokenStore } from '@/stores'
 import { endpoints } from '@/api/endpoints'
 
 interface FailedQueue {
-  resolve: (value: unknown) => void
+  resolve: (token: string) => void
   reject: (reason?: unknown) => void
 }
 

--- a/src/api/axios/interceptors/refresh-token.ts
+++ b/src/api/axios/interceptors/refresh-token.ts
@@ -4,35 +4,73 @@ import { fetches } from '@/api/fetches'
 import { useTokenStore } from '@/stores'
 import { endpoints } from '@/api/endpoints'
 
+interface FailedQueue {
+  resolve: (value: unknown) => void
+  reject: (reason?: unknown) => void
+}
+
+let isRefreshing = false
+let failedQueue: FailedQueue[] = []
+
 export function setupRefreshTokenInterceptor() {
   AXIOS.interceptors.response.use(
     (response) => response,
     async (error) => {
       if (!isAxiosError(error)) {
-        throw error
+        return Promise.reject(error)
       }
       if (!error.response) {
-        throw error
+        return Promise.reject(error)
       }
-      if (error.response.status === 401) {
-        if (error.config?.url !== endpoints.auth.reissue) {
-          console.log('리프레시 토큰 사용하여 재발급 시도')
-          const { token } = await fetches.auth.reissue()
-          useTokenStore.getState().setAccessToken(token)
+      if (!error.config) {
+        return Promise.reject(error)
+      }
+      if (error.response.status !== 401) {
+        return Promise.reject(error)
+      }
 
-          if (error.config) {
-            // 기본적으로 `useTokenStore`에 새로운 엑세스 토큰을 저장하면, `accessTokenInterceptor`가 자동으로 새로운 헤더를 추가함
-            // 따라서 아래의 코드는 불필요할 수 있지만, subscribe가 비동기로 동작하므로 아래의 코드를 명시적으로 작성함
-            console.log('엑세스 토큰 재발급 후 헤더 추가 + 요청 재시도')
-            error.config.headers.Authorization = `Bearer ${token}`
-            return AXIOS(error.config)
-          }
-        } else {
-          console.log('엑세스 토큰 재발급 실패')
-          useTokenStore.getState().clearAccessToken()
-        }
+      const originalRequest = error.config
+
+      // 엑세스 토큰 재발급에 실패한 경우
+      if (originalRequest.url === endpoints.auth.reissue) {
+        return Promise.reject(error)
       }
-      throw error
+
+      // 이미 재발급이 진행중인 경우
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject })
+        })
+          .then((token) => {
+            originalRequest.headers.Authorization = `Bearer ${token}`
+            return AXIOS(originalRequest)
+          })
+          .catch((err) => {
+            return Promise.reject(err)
+          })
+      }
+
+      // 첫 재발급 시도
+      isRefreshing = true
+
+      try {
+        const { token } = await fetches.auth.reissue()
+
+        useTokenStore.getState().setAccessToken(token)
+        originalRequest.headers.Authorization = `Bearer ${token}`
+
+        failedQueue.forEach((failed) => failed.resolve(token))
+        failedQueue = []
+
+        return await AXIOS(originalRequest)
+      } catch (err) {
+        failedQueue.forEach((failed) => failed.reject(err))
+        failedQueue = []
+        useTokenStore.getState().clearAccessToken()
+        return Promise.reject(err)
+      } finally {
+        isRefreshing = false
+      }
     }
   )
 }


### PR DESCRIPTION
jwt 인증에서 액세스 토큰 만료 시 자동으로 동작하는 리프레시 토큰 axios 인터셉터의 로직상 문제를 해결하였습니다.

### 문제 원인

기존에는 단순히 401 에러 발생 시, `refreshTokenInterceptor`에서 이를 확인하고 요청을 가로챈 다음, 내부적으로 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받고, 발급받은 액세스 토큰을 이용해 기존에 실패한 api 요청을 재시도하고 그 결과를 반환하도록 설계하였습니다. 덕분에 사용자는 중간에 액세스 토큰이 만료되더라도 요청이 끊기지 않고 자연스럽게 계속 로그인 되어 있는 듯한 효과를 얻을 수 있습니다.

하지만 해당 방식은 동시에 여러 api 요청 시 문제가 발생할 수 있었고, 이 문제를 이번에 발견하였습니다. 현재 화면 구성상, 오랫동안 사용하지 않다가 서비스에 접속하게 되면 초기 서비스 UI 구성을 위해 여러 다양한 api를 동시에 요청하고 있습니다. 이때 이러한 api 요청은 동시에 가깝게 발생하고, 그에 대한 결과를 네트워크에서 받아오기까지는 요청 시간에 비해 매우 느립니다.

그렇기에 액세스 토큰이 만료된 상태에서 한번에 여러 api가 요청되는 경우, 잠깐의 네트워크 지연 이후 그 수 만큼의 401 에러를 반환받게 되고, 각 요청에 달린 인터셉터가 각 요청마다 새로운 리프레시 요청을 보내게 됩니다. 이 과정에서 서버로부터 여러번의 리프레시 요청을 동시에 보내게 되고, 각 api가 전달받은 리프레시 토큰 및 액세스 토큰이 사용하려고 하면 이미 다른 인터셉터의 리프레시 요청에 의해 바로 만료가 되어버리는 문제가 발생했습니다.

### 문제 해결

리프레시 요청이라는 하나의 사항을 여러 컴포넌트에서 요청한 각 api 마다 동시에 처리를 하려다보니 일어나는 이 문제는, 마치 하나의 자원에 여러 스레드가 동시에 접근하려는 상황과 비슷했습니다. 따라서 비슷하게 간단한 락 시스템과 재시도 큐를 내부적으로 구성하여 활용하는 방식으로 문제를 해결했습니다.

먼저 `isRefreshing`이라는 `boolean` 변수를 통해 가장 최초로 리프레시 요청을 시도한 api 가 존재한다면, 이후에는 리프레시 요청이 중복해서 발생하지 않도록 하였습니다. 첫 리프레시 시도 이후에 바로 이어서 발생한 리프레시 요청이 필요한 api의 경우 따로 `FailedQueue`라는 큐에 `Promise`를 제어할 수 있는 `resolve`와 `reject`를 넘겨주어 보관하였고, 이후 첫 번쨰 리프레시 요청에 대한 값으로 액세스 토큰 새로 전달받으면, 그 이후에 해당 액세스 토큰을 `resolve`에 넘겨주어 일괄적으로 문제있던 api들을 재시도하도록 설계하였습니다.