### PR TITLE
[GOMO-182] 메인 모달창 개선

### DIFF
--- a/src/components/icon-button/sidebar.tsx
+++ b/src/components/icon-button/sidebar.tsx
@@ -4,11 +4,12 @@ import { Iconify } from '@/components/iconify'
 
 interface SidebarProps {
   onClick?: () => void
+  disabled?: boolean
 }
 
-export function Sidebar({ onClick }: SidebarProps) {
+export function Sidebar({ onClick, disabled }: SidebarProps) {
   return (
-    <IconButton sx={IconButtonSx} onClick={onClick}>
+    <IconButton sx={IconButtonSx} onClick={onClick} disabled={disabled}>
       <Iconify icon="material-symbols:side-navigation" width={20} />
     </IconButton>
   )

--- a/src/components/modal/main-view/main-view-sidebar.tsx
+++ b/src/components/modal/main-view/main-view-sidebar.tsx
@@ -1,6 +1,7 @@
 import { IconButtons } from '@/components/icon-button'
 import { MainViewSidebarItem } from '@/components/modal/main-view/main-view-sidebar-item'
 import { Box, Stack, SxProps, Theme, Typography } from '@mui/material'
+import { motion } from 'motion/react'
 import { Fragment, ReactNode } from 'react'
 
 export const MAIN_VIEW_SIDEBAR_WIDTH = 200
@@ -23,6 +24,10 @@ interface MainViewSidebarProps<T> {
   onSelected?: (id: T) => void
   actions?: ReactNode[]
   actionSx?: SxProps<Theme>
+  collapsed?: boolean
+  onCollapse?: () => void
+  isPeeking?: boolean
+  onPeekingOut?: () => void
 }
 
 export function MainViewSidebar<T>({
@@ -31,6 +36,10 @@ export function MainViewSidebar<T>({
   onSelected,
   actions,
   actionSx,
+  collapsed,
+  onCollapse,
+  isPeeking,
+  onPeekingOut,
 }: MainViewSidebarProps<T>) {
   const menuClickHandler = (id: T, onClick?: () => void) => {
     if (onClick) {
@@ -42,14 +51,26 @@ export function MainViewSidebar<T>({
 
   return (
     <Stack
+      component={motion.div}
       width={MAIN_VIEW_SIDEBAR_WIDTH}
       borderRight={1}
       borderColor={(theme) => theme.palette.border.main}
       bgcolor={(theme) => theme.palette.background.main}
       flexShrink={0}
+      initial={{ transform: collapsed && !isPeeking ? 'translateX(-100%)' : 'translateX(0)' }}
+      animate={{
+        transform: collapsed && !isPeeking ? 'translateX(-100%)' : 'translateX(0)',
+      }}
+      transition={{ duration: 0.2 }}
+      position="absolute"
+      zIndex={10}
+      top={0}
+      left={0}
+      bottom={0}
+      onMouseLeave={isPeeking ? onPeekingOut : undefined}
     >
       <Stack p={0.5} borderBottom={1} borderColor={(theme) => theme.palette.border.main}>
-        <IconButtons.Sidebar />
+        <IconButtons.Sidebar onClick={onCollapse} />
       </Stack>
 
       <Stack

--- a/src/components/modal/main-view/main-view-sidebar.tsx
+++ b/src/components/modal/main-view/main-view-sidebar.tsx
@@ -28,6 +28,7 @@ interface MainViewSidebarProps<T> {
   onCollapse?: () => void
   isPeeking?: boolean
   onPeekingOut?: () => void
+  disableCollapse?: boolean
 }
 
 export function MainViewSidebar<T>({
@@ -40,6 +41,7 @@ export function MainViewSidebar<T>({
   onCollapse,
   isPeeking,
   onPeekingOut,
+  disableCollapse,
 }: MainViewSidebarProps<T>) {
   const menuClickHandler = (id: T, onClick?: () => void) => {
     if (onClick) {
@@ -70,7 +72,7 @@ export function MainViewSidebar<T>({
       onMouseLeave={isPeeking ? onPeekingOut : undefined}
     >
       <Stack p={0.5} borderBottom={1} borderColor={(theme) => theme.palette.border.main}>
-        <IconButtons.Sidebar onClick={onCollapse} />
+        <IconButtons.Sidebar onClick={onCollapse} disabled={disableCollapse} />
       </Stack>
 
       <Stack

--- a/src/components/modal/main-view/main-view.tsx
+++ b/src/components/modal/main-view/main-view.tsx
@@ -100,6 +100,7 @@ export function MainView<T>({
             onCollapse={isCollapsed.toggle}
             isPeeking={isPeeking.value}
             onPeekingOut={isPeeking.onFalse}
+            disableCollapse={isAutoCollapse}
           />
           <Box
             flex={1}

--- a/src/components/modal/main-view/main-view.tsx
+++ b/src/components/modal/main-view/main-view.tsx
@@ -6,7 +6,7 @@ import {
 import { MainViewTitle } from '@/components/modal/main-view/main-view-title'
 import { useBoolean } from '@/hooks'
 import { useModalStore } from '@/stores/use-modal-store'
-import { Box, Dialog, SxProps, Stack, Theme } from '@mui/material'
+import { Box, Dialog, SxProps, Stack, Theme, useMediaQuery } from '@mui/material'
 import { motion } from 'motion/react'
 import { ReactNode, useEffect } from 'react'
 
@@ -40,11 +40,22 @@ export function MainView<T>({
   const { removeModal } = useModalStore()
 
   const isCollapsed = useBoolean()
-  const isPeeking = useBoolean(true)
+  const isPeeking = useBoolean(false)
+
+  const isAutoCollapse = useMediaQuery('(max-width: 700px)')
+
+  useEffect(() => {
+    if (isAutoCollapse) {
+      isCollapsed.onTrue()
+      return
+    }
+    isCollapsed.onFalse()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAutoCollapse])
 
   useEffect(() => {
     if (isCollapsed.value) {
-      isPeeking.onTrue()
+      isPeeking.onFalse()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isCollapsed.value])

--- a/src/components/modal/main-view/main-view.tsx
+++ b/src/components/modal/main-view/main-view.tsx
@@ -1,11 +1,14 @@
 import {
+  MAIN_VIEW_SIDEBAR_WIDTH,
   MainViewSidebar,
   MainViewSidebarMenuGroup,
 } from '@/components/modal/main-view/main-view-sidebar'
 import { MainViewTitle } from '@/components/modal/main-view/main-view-title'
+import { useBoolean } from '@/hooks'
 import { useModalStore } from '@/stores/use-modal-store'
 import { Box, Dialog, SxProps, Stack, Theme } from '@mui/material'
-import { ReactNode } from 'react'
+import { motion } from 'motion/react'
+import { ReactNode, useEffect } from 'react'
 
 interface MainViewProps<T> {
   modalId: string
@@ -36,6 +39,18 @@ export function MainView<T>({
 }: MainViewProps<T>) {
   const { removeModal } = useModalStore()
 
+  const isCollapsed = useBoolean()
+  const isPeeking = useBoolean(true)
+
+  useEffect(() => {
+    if (isCollapsed.value) {
+      isPeeking.onTrue()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isCollapsed.value])
+
+  useEffect(() => {}, [isPeeking.value])
+
   return (
     <Dialog
       open
@@ -52,17 +67,37 @@ export function MainView<T>({
         },
       }}
     >
+      {isCollapsed.value && !isPeeking.value && (
+        <Box
+          position="absolute"
+          width="50px"
+          height={1}
+          onMouseEnter={isPeeking.onTrue}
+          zIndex={11}
+        />
+      )}
       <Stack width={1} height={1}>
         <MainViewTitle title={title} subtitle={subtitle} onClose={() => removeModal(modalId)} />
-        <Stack direction="row" width={1} height={1} overflow="hidden">
+        <Stack direction="row" width={1} height={1} overflow="hidden" position="relative">
           <MainViewSidebar
             menu={sidebar}
             selectedMenuId={selectedMenuId}
             onSelected={onSelected}
             actions={actions}
             actionSx={actionSx}
+            collapsed={isCollapsed.value}
+            onCollapse={isCollapsed.toggle}
+            isPeeking={isPeeking.value}
+            onPeekingOut={isPeeking.onFalse}
           />
-          <Box flex={1} sx={{ overflowY: 'auto', overflowX: 'hidden' }}>
+          <Box
+            flex={1}
+            component={motion.div}
+            initial={{ marginLeft: isCollapsed.value ? 0 : MAIN_VIEW_SIDEBAR_WIDTH }}
+            animate={{ marginLeft: isCollapsed.value ? 0 : MAIN_VIEW_SIDEBAR_WIDTH }}
+            transition={{ duration: 0.2 }}
+            sx={{ overflowY: 'auto', overflowX: 'hidden' }}
+          >
             {children}
           </Box>
         </Stack>

--- a/src/components/modal/main-view/main-view.tsx
+++ b/src/components/modal/main-view/main-view.tsx
@@ -60,8 +60,6 @@ export function MainView<T>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isCollapsed.value])
 
-  useEffect(() => {}, [isPeeking.value])
-
   return (
     <Dialog
       open
@@ -77,6 +75,7 @@ export function MainView<T>({
           borderColor: (theme) => theme.palette.border.main,
         },
       }}
+      disableEscapeKeyDown
     >
       {isCollapsed.value && !isPeeking.value && (
         <Box

--- a/src/components/modal/modal-manager.tsx
+++ b/src/components/modal/modal-manager.tsx
@@ -1,8 +1,20 @@
 import { useModalStore } from '@/stores/use-modal-store'
-import { Fragment } from 'react'
+import { Fragment, useEffect } from 'react'
 
 export function ModalManager() {
-  const { modals } = useModalStore()
+  const { modals, popModal } = useModalStore()
+
+  useEffect(() => {
+    const keyDownHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        popModal()
+      }
+    }
+    document.addEventListener('keydown', keyDownHandler)
+    return () => {
+      document.removeEventListener('keydown', keyDownHandler)
+    }
+  }, [popModal])
 
   return (
     <>

--- a/src/components/modal/modal-view/modal-view.tsx
+++ b/src/components/modal/modal-view/modal-view.tsx
@@ -23,6 +23,7 @@ export function ModalView({ width = 450, height = 600, children }: ModalViewProp
           borderColor: (theme) => theme.palette.border.main,
         },
       }}
+      disableEscapeKeyDown
     >
       {children}
     </Dialog>

--- a/src/stores/use-modal-store.ts
+++ b/src/stores/use-modal-store.ts
@@ -10,10 +10,12 @@ interface ModalState {
   modals: Modal[]
   addModal: (id: string, component: ReactNode) => void
   removeModal: (id: string) => void
+  popModal: () => void
 }
 
 export const useModalStore = create<ModalState>((set) => ({
   modals: [],
   addModal: (id, component) => set((state) => ({ modals: [...state.modals, { id, component }] })),
   removeModal: (id) => set((state) => ({ modals: state.modals.filter((m) => m.id !== id) })),
+  popModal: () => set((state) => ({ modals: state.modals.slice(0, -1) })),
 }))


### PR DESCRIPTION
메인 모달창의 사이드바를 접었다 펼 수 있도록 기능을 추가하였습니다.

사이드바를 접을 경우 완전히 사라지게 되고, 마우스를 모달창 왼쪽 가장자리에 가져다대면 기존 컨텐츠 영역 위로 사이드바가 나타났다가, 다시 마우스를 사이드바에서 떨어뜨리면 다시 들어가게 됩니다.

또한 브라우저의 사이즈에 대응하여 일정 크기 이하로 브라우저가 줄어들면 자동으로 사이드바가 접히며, 일정 크기 이상으로 늘어나면 자동으로 다시 나타납니다. 이때 브라우저 크기가 작아 접혀진 사이드바는 항상 펴진 상태로 전환할 수 없습니다. (버튼이 자동 비활성화 됩니다.)

추가로 모든 모달창을 이제 우측 상단의 X 버튼뿐 아니라 키보드 `esc`키를 사용해서도 닫을 수 있도록 키세팅을 추가하였습니다.

![모달 사이드바 접기1](https://github.com/user-attachments/assets/f79a86c6-e631-4538-b077-4917cdfbf8f8)

![모달 사이드바 접기2](https://github.com/user-attachments/assets/0afc3b2f-9df2-43a6-b6f3-ee4e970b2957)
